### PR TITLE
Magic Encoding Warning suppress / Use newest Flog#process_iter method

### DIFF
--- a/plugin/flog.vim
+++ b/plugin/flog.vim
@@ -160,7 +160,10 @@ options = {
 
 flogger = Flog.new options
 flogger.flog ::VIM::Buffer.current.name
-show_complexity flogger.return_report
+begin
+  show_complexity flogger.return_report
+rescue
+end
 
 EOF
 

--- a/plugin/flog.vim
+++ b/plugin/flog.vim
@@ -126,7 +126,6 @@ class Flog
 end
 
 def show_complexity(results = {})
-  return if Vim::Buffer.current.name.match("_spec")
   VIM.command ":silent sign unplace file=#{VIM::Buffer.current.name}"
   results.each do |line_number, rest|
     medium_limit = VIM::evaluate('s:medium_limit')

--- a/plugin/flog.vim
+++ b/plugin/flog.vim
@@ -158,9 +158,9 @@ options = {
       :all      => true
     }
 
-flogger = Flog.new options
-flogger.flog ::VIM::Buffer.current.name
 begin
+  flogger = Flog.new options
+  flogger.flog ::VIM::Buffer.current.name
   show_complexity flogger.return_report
 rescue
 end


### PR DESCRIPTION
I was running into issues with the ruby_parser warning - "Skipping magic encoding comment" every time I saved a file - The comment had an extra '\n' that was causing Vim to redraw the screen in odd ways - This pull request overwrites the original method but only by commenting out the warning.  

I also pulled out the overwritten Flog#process_iter method and allowed the plugin to use the original from the newest Flog gem - This solved the issues I was getting while loading spec files.
